### PR TITLE
[Feat] 인증/인가 구현 - Swagger 문제 수정

### DIFF
--- a/src/main/java/tetoandeggens/seeyouagainbe/global/config/SwaggerConfig.java
+++ b/src/main/java/tetoandeggens/seeyouagainbe/global/config/SwaggerConfig.java
@@ -4,9 +4,12 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+
+import java.util.List;
 
 @Configuration
 @Profile({"local", "dev", "prod"})
@@ -15,6 +18,11 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
+                .servers(List.of(
+                        new Server()
+                                .url("/")
+                                .description("현재 서버")
+                ))
                 .info(new Info()
                         .title("SeeYouAgain API Document")
                         .description("SeeYouAgain 서버 API 명세서입니다.")


### PR DESCRIPTION
## #1 
## 📝 요약(Summary)

Swagger UI에서 Mixed Content 에러가 발생하여 API 테스트가 불가능한 문제가 발생했습니다. HTTPS로 접속한 Swagger UI가 HTTP 프로토콜로 API 요청을 생성하면서 브라우저의 Mixed Content 정책에 의해 요청이 차단되었습니다. 해결을 위해 SwaggerConfig 파일에 서버 URL을 상대 경로("/")로 설정하여 Swagger가 현재 접속한 도메인과 프로토콜을 자동으로 사용하도록 수정했습니다.

## 📸스크린샷 (선택)
<img width="1895" height="903" alt="image" src="https://github.com/user-attachments/assets/0d4066c3-8797-4305-b104-9c158ff8adbe" />