### PR TITLE
[FIX] 배포시 불필요한 테스트 스킵

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -46,7 +46,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build -x test
 
       - name: Generate Version Tag
         id: generate_tag


### PR DESCRIPTION
## #79 

## 📝 요약(Summary)

prod 배포를 하는 과정에서 bastion host에 docker가 없다보니 Testcontainers 실행 불가능한 상황이었기에 어차피 테스트 코드는 ci에서 진행하므로 cd에서는 배포에만 집중하기로 수정했습니다. 

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->