### PR TITLE
[FIX] WebSocket 연결 실패

### DIFF
--- a/src/main/java/tetoandeggens/seeyouagainbe/global/config/WebSocketConfig.java
+++ b/src/main/java/tetoandeggens/seeyouagainbe/global/config/WebSocketConfig.java
@@ -48,7 +48,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws-stomp")
 			.setAllowedOriginPatterns(
-				"https://seeyouagain.store"
+                "https://seeyouagain.store",
+                "https://www.seeyouagain.store",
+                "https://prod-api.seeyouagain.store",
+                "http://localhost:3000"
 			)
 			.setHandshakeHandler(customHandshakeHandler)
 			.addInterceptors(handshakeInterceptor)


### PR DESCRIPTION
## #85 

## 📝 요약(Summary)

프로덕션 환경에서 프론트엔드가 https://prod-api.seeyouagain.store를 통해 WebSocket 연결을 시도할 때 CORS 에러로 인해 연결이 실패하는 문제를 수정했습니다.WebSocketConfig의 allowedOriginPatterns에 prod-api.seeyouagain.store, www.seeyouagain.store, localhost:3000 도메인을 추가하여 SecurityConfig의 CORS 설정과 일치시켰습니다.

왜 수정했는가?
WebSocket 핸드셰이크는 SecurityConfig의 CORS와 별도로 WebSocketConfig의 CORS 설정을 체크합니다
SecurityConfig에는 모든 도메인이 등록되어 있었지만, WebSocketConfig에는 메인 도메인만 있어 불일치가 발생했습니다
이로 인해 프로덕션 API 도메인으로의 WebSocket 연결이 차단되었습니다

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어