### PR TITLE
[FIX] 채팅 페이징에서 cursorId 메시지 누락 문제 수정시 LATEST에서도 포함

### DIFF
--- a/src/main/java/tetoandeggens/seeyouagainbe/chat/repository/custom/ChatMessageRepositoryCustomImpl.java
+++ b/src/main/java/tetoandeggens/seeyouagainbe/chat/repository/custom/ChatMessageRepositoryCustomImpl.java
@@ -121,7 +121,7 @@ public class ChatMessageRepositoryCustomImpl implements ChatMessageRepositoryCus
 			return null;
 		}
 		return sortDirection == SortDirection.LATEST
-			? chatMessage.id.lt(cursorId)
+			? chatMessage.id.loe(cursorId)
 			: chatMessage.id.goe(cursorId);
 	}
 

--- a/src/test/java/tetoandeggens/seeyouagainbe/chat/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/tetoandeggens/seeyouagainbe/chat/repository/ChatMessageRepositoryTest.java
@@ -143,21 +143,22 @@ class ChatMessageRepositoryTest extends RepositoryTest {
 		void findMessagesByChatRoom_WithCursor() {
 			// given
 			List<ChatMessage> firstPage = chatMessageRepository.findMessagesByChatRoom(
-				chatRoom.getId(), null, 2, SortDirection.LATEST
+					chatRoom.getId(), null, 2, SortDirection.LATEST
 			);
 
 			assertThat(firstPage).hasSizeLessThanOrEqualTo(3);
 			assertThat(firstPage).hasSizeGreaterThanOrEqualTo(2);
+
 			Long cursorId = firstPage.get(1).getId();
 
 			// when
 			List<ChatMessage> secondPage = chatMessageRepository.findMessagesByChatRoom(
-				chatRoom.getId(), cursorId, 2, SortDirection.LATEST
+					chatRoom.getId(), cursorId, 2, SortDirection.LATEST
 			);
 
 			// then
 			assertThat(secondPage).isNotEmpty();
-			assertThat(secondPage).allMatch(msg -> !msg.getId().equals(cursorId));
+			assertThat(secondPage).anyMatch(msg -> msg.getId().equals(cursorId));
 		}
 
 		@Test


### PR DESCRIPTION
## #103 

## 📝 요약(Summary)

정렬로 채팅 메시지를 커서 페이징 조회 시, OLDEST에만 cursorId 메시지 누락 문제가 적용되어서 LATEST에서도 적용되도록 수정했습니다.

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어